### PR TITLE
Potential fix for [https://github.com/carlesloriente/nocc-bootstrap-t…

### DIFF
--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches-ignore:
     - main
+permissions:
+  contents: read
 jobs:
   build:
     name: build

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -5,6 +5,8 @@ on:
       - main
     types:
       - closed
+permissions:
+  contents: write
 jobs:
   build:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
…heme/security/code-scanning/6](https://github.com/carlesloriente/nocc-bootstrap-theme/security/code-scanning/6)

To fix this issue, add a `permissions` block as close to the top of the workflow file as possible (ideally at the root, above the `jobs:` key), explicitly declaring exactly which permissions are needed. This workflow performs git pushes and publishes to npm, so minimally it needs `contents: write` to push tags/code; no other special permissions (such as `pull-requests: write`) are apparently required. To implement the fix:

- Edit `.github/workflows/publish-release.yml`
- Insert at top level (directly after `name:` and `on:`, before `jobs:`) ```yaml permissions: contents: write ```
- No additional package dependencies or changes are required.

---